### PR TITLE
Add weather toggle button and replace Sun with Lightbulb in dark mode toggle

### DIFF
--- a/apps/www-tron/lib/components/site/AppLayout.tsx
+++ b/apps/www-tron/lib/components/site/AppLayout.tsx
@@ -5,6 +5,7 @@ import { PageViews } from '@/lib/components/site/page-views'
 import { ClickCountToggle } from '@/lib/components/site/click-count-toggle'
 import { DarkModeToggle } from '@/lib/components/site/dark-mode-toggle'
 import { ThemeToggle } from '@/lib/components/site/theme-toggle'
+import { WeatherToggle } from '@/lib/components/site/weather-toggle'
 import { GitHubIcon, XIcon, LinkedInIcon } from '@/lib/components/icons'
 import { profileData } from '@/lib/portfolio-data'
 import type { NavLink } from '@/lib/navigation'
@@ -47,6 +48,7 @@ export function AppLayout({ children, navLinks }: { children: React.ReactNode; n
         </div>
         <div className="flex items-center gap-4">
           <ClickCountToggle />
+          <WeatherToggle />
           <DarkModeToggle />
           <ThemeToggle />
         </div>

--- a/apps/www-tron/lib/components/site/dark-mode-toggle.tsx
+++ b/apps/www-tron/lib/components/site/dark-mode-toggle.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Moon, Sun } from "lucide-react"
+import { Lightbulb, Moon } from "lucide-react"
 import { useEffect, useState } from "react"
 
 export function DarkModeToggle() {
@@ -58,7 +58,7 @@ export function DarkModeToggle() {
       {mode === "dark" ? (
         <Moon className="size-3.5 text-foreground" />
       ) : (
-        <Sun className="size-3.5 text-foreground" />
+        <Lightbulb className="size-3.5 text-foreground" />
       )}
     </button>
   )

--- a/apps/www-tron/lib/components/site/weather-toggle.tsx
+++ b/apps/www-tron/lib/components/site/weather-toggle.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { Cloud, CloudDrizzle, CloudLightning, Sun } from "lucide-react"
+import { useEffect, useState } from "react"
+
+const weatherStates = ["sunny", "overcast", "rain", "storm"] as const
+type WeatherState = (typeof weatherStates)[number]
+
+const weatherIcons = {
+  sunny: Sun,
+  overcast: Cloud,
+  rain: CloudDrizzle,
+  storm: CloudLightning,
+} as const
+
+const weatherLabels = {
+  sunny: "Sunny",
+  overcast: "Overcast",
+  rain: "Light rain",
+  storm: "Downpour with lightning",
+} as const
+
+export function WeatherToggle() {
+  const [weather, setWeather] = useState<WeatherState>("sunny")
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    const stored = localStorage.getItem("tron-weather") as WeatherState | null
+    if (stored && weatherStates.includes(stored)) {
+      setWeather(stored)
+    }
+  }, [])
+
+  const cycleWeather = () => {
+    const currentIndex = weatherStates.indexOf(weather)
+    const nextIndex = (currentIndex + 1) % weatherStates.length
+    const next = weatherStates[nextIndex]
+    setWeather(next)
+    localStorage.setItem("tron-weather", next)
+  }
+
+  const Icon = weatherIcons[weather]
+
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        disabled
+        className="inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-xl border border-border text-foreground bg-muted transition-colors"
+      >
+        <Sun className="size-3.5" />
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      data-click-id="nav:weather"
+      onClick={cycleWeather}
+      title={`Weather: ${weatherLabels[weather]}. Click to cycle.`}
+      className="inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-xl border border-border text-foreground bg-muted hover:bg-muted/80 transition-colors cursor-pointer"
+    >
+      <Icon className="size-3.5 text-foreground" />
+    </button>
+  )
+}


### PR DESCRIPTION
Introduce a new weather toggle button in the footer that cycles through
sunny (Sun), overcast (Cloud), light rain (CloudDrizzle), and storm
(CloudLightning) states. Replace the Sun icon in the dark mode toggle
with Lightbulb to avoid icon collision, since Sun is now used for the
weather toggle's sunny state.

https://claude.ai/code/session_01TPJHg65W3neo7Gt2H4bQKm