### PR TITLE
Remove redundant GitHub link from footer

### DIFF
--- a/packages/www/lib/ui/blocks/footer.tsx
+++ b/packages/www/lib/ui/blocks/footer.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import Github from "../icons/github";
 
 export function Footer({ className }: { className?: string }) {
   return (
@@ -13,20 +12,6 @@ export function Footer({ className }: { className?: string }) {
       <div className="mx-auto flex flex-col-reverse sm:flex-row gap-4 max-w-7xl items-center justify-between">
         <div>
           <span className="flex items-center gap-1 text-muted-foreground">
-            <Link
-              href="https://github.com/clay-curry/claycurry.com"
-              className="hover:underline text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-              target="_blank"
-              rel="noopener"
-            >
-              <Github />
-            </Link>
-
-            <div
-              className="border-l h-4 mx-1 self-center"
-              aria-hidden="true"
-            ></div>
-
             <Link
               href="https://github.com/clay-curry/claycurry.com/blob/main/LICENSE.md"
               className="hover:underline text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"


### PR DESCRIPTION
The GitHub link is already present in the homepage social links, so the duplicate in the footer is unnecessary.

https://claude.ai/code/session_01Czh1DFSmr9z5Pj9Q2oAGdw