### PR TITLE
style(www): update hero styling and condense about description

### DIFF
--- a/apps/www/lib/components/site/hero.tsx
+++ b/apps/www/lib/components/site/hero.tsx
@@ -10,7 +10,9 @@ function HeroPrimaryText({ children }: { children: React.ReactNode }) {
 
 function HeroSubtext({ children }: { children: React.ReactNode }) {
   return (
-    <p className="text-lg md:text-xl text-muted-foreground mb-10">{children}</p>
+    <p className="text-lg md:text-xl text-muted-foreground italic mb-10">
+      {children}
+    </p>
   );
 }
 
@@ -18,7 +20,7 @@ export function Hero() {
   return (
     <div className="text-center py-20">
       <HeroPrimaryText>Clay Curry</HeroPrimaryText>
-      <HeroSubtext>Portfolio Website</HeroSubtext>
+      <HeroSubtext>PORTFOLIO WEBSITE</HeroSubtext>
       <HeroContactAskAI />
     </div>
   );

--- a/apps/www/lib/portfolio-data.ts
+++ b/apps/www/lib/portfolio-data.ts
@@ -19,8 +19,7 @@ export const siteConfig = {
 
 export const aboutData = {
   description: [
-    "I am a software engineer passionate about building products that rely on mechanisms to continuously learn from user behavior through feedback loops. I value working on teams that build iteratively, make pragmatic technology choices, and ship work I can personally stand behind.",
-    "I am especially drawn to the intersection of AI/ML and web platforms, where intelligent systems and great design converge.",
+    "Product engineer drawn to ambitious yet pragmatic teams that use feedback loops with users to ship work worth defending. I am particularly energized by the intersection of DX, AI/ML and well-crafted web experiences — where smarts and great design meet.",
   ],
   skills: [
     "Claude Code",


### PR DESCRIPTION
## Summary
- Make hero subtext italic and uppercase ("PORTFOLIO WEBSITE")
- Condense the about description from two paragraphs into a single concise paragraph

## Test plan
- [ ] Verify hero section renders with italic, uppercase subtext
- [ ] Verify about section displays the updated single-paragraph description
- [ ] Check responsive layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)