### PR TITLE
fix(www): smooth ease-out transition for mobile nav drawer

### DIFF
--- a/apps/www/lib/components/ui/sheet.tsx
+++ b/apps/www/lib/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-300 data-[state=open]:duration-300 fixed inset-0 z-50 bg-black/50",
         className,
       )}
       {...props}
@@ -60,7 +60,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg data-[state=closed]:duration-150 data-[state=open]:duration-150",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg will-change-transform ease-out data-[state=closed]:duration-300 data-[state=open]:duration-300",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
## Summary
- Increase sheet slide animation from 150ms to 300ms with `ease-out` easing
- Add `will-change-transform` for GPU-accelerated animation
- Sync overlay fade duration to 300ms to match drawer timing

Closes #45

## Test plan
- [ ] Open mobile nav drawer — should slide in smoothly from the left
- [ ] Close drawer — should slide back out with matching reverse animation
- [ ] Backdrop should fade in/out in sync with the drawer
- [ ] Verify no layout jank on iOS Safari and Android Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)